### PR TITLE
add updateHostRoleFullnames() to method

### DIFF
--- a/src/Mackerel/Client.php
+++ b/src/Mackerel/Client.php
@@ -140,7 +140,6 @@ class Client
      */
     public function updateHostRoleFullnames($hostId, array $roleFullnames)
     {
-
         $path = sprintf('/api/v0/hosts/%s/role-fullnames', $hostId);
         $response = $this->client->put($path, [
             'body' => json_encode([

--- a/src/Mackerel/Client.php
+++ b/src/Mackerel/Client.php
@@ -133,6 +133,28 @@ class Client
     }
 
     /**
+     * @param $hostId
+     * @param array $roleFullnames
+     * @return mixed
+     * @throws \Exception
+     */
+    public function updateHostRoleFullnames($hostId, array $roleFullnames)
+    {
+
+        $path = sprintf('/api/v0/hosts/%s/role-fullnames', $hostId);
+        $response = $this->client->put($path, [
+            'body' => json_encode([
+                'roleFullnames' => $roleFullnames,
+            ]),
+        ]);
+
+        if ($response->getStatusCode() != 200) {
+            throw new \Exception(sprintf('POST %s failed: %d', $path, $response->getStatusCode()));
+        }
+        return json_decode($response->getBody()->getContents(), true);
+    }
+
+    /**
      * @param string $hostId
      * @return Host
      * @throws \Exception


### PR DESCRIPTION
Function was added with reference to mackerel-client-go
- https://github.com/mackerelio/mackerel-client-go/blob/master/hosts.go#L253

This method changes the role associated with host in Mackerel

# how to use
```
$client = new \Mackerel\Client([
    'mackerel_api_key' => $mackerel_api_key,
]);

$roleFullnames = ['service_name:role_name'];

$result = $client->updateHostRoleFullnames($hostId, $roleFullnames);
```