### PR TITLE
Compatible with PHP 7.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,6 @@
     },
     "require": {
         "php": ">=5.6.0",
-        "guzzlehttp/guzzle": "6.2.2"
+        "guzzlehttp/guzzle": "6.3.3"
     }
 }


### PR DESCRIPTION
- count(): Parameter must be an array or an object that implements Countable
- https://github.com/guzzle/guzzle/issues/1973

So give me the version of guzzlehttp